### PR TITLE
[Combat] Step On Bug

### DIFF
--- a/src/game/entity/definitions/player.h
+++ b/src/game/entity/definitions/player.h
@@ -16,10 +16,18 @@ typedef enum {
     entity_player_status_bagofchips = 4,
     entity_player_status_glowstick = 8,
     entity_player_status_superglue = 16,
+
+
+    // When player steps on a bug they're set to stepedon_1. After 1000 update ticks they're lowered to _2, then _3, etc.
+    // Between the transition of from 1->2->3 there is a 20% chance the player will drop an egg.
+    entity_player_status_stepedon_1 = 32,
+    entity_player_status_stepedon_2 = 64,
+    entity_player_status_stepedon_3 = 128,
+
 } entity_player_status_t;
 
 void entity_player_init(entity_t *entity);
-void entity_player_touching_wall(entity_t *entity, entity_touch_wall_t wall);
+void entity_player_touching(entity_t *entity, entity_t *them);
 void entity_player_free(entity_t *entity);
 void entity_player_update(entity_t *entity);
 void entity_player_draw(entity_t *entity);


### PR DESCRIPTION
When a player steps on a bug track it as a player status. This player
status then causes a state machine to transition from state to state
every 1000 ticks. At each transition there will be a chance to run an
event.